### PR TITLE
Bound version-file lookup to the repo, warn on stale manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ usage: versions [options] patch|minor|major|prerelease [files...]
 
   Options:
     -a, --all             Add all changed files to the commit
-    -b, --base <version>  Base version. Default is from latest git tag or 0.0.0
+    -b, --base <version>  Base version. Default is from latest git tag, package.json, pyproject.toml, or 0.0.0
     -p, --prefix          Prefix version string with a "v" character. Default is none
     -c, --command <cmd>   Run command after files are updated but before git commit and tag
     -d, --date [<date>]   Replace dates in format YYYY-MM-DD with current or given date

--- a/api.ts
+++ b/api.ts
@@ -74,18 +74,18 @@ export function findUp(filename: string, dir: string, stopDir?: string): string 
   }
 }
 
-function readVersionFile(filename: string, dir: string, parse: (content: string) => string | undefined): string | null {
-  const path = findUp(filename, dir);
+function readVersionFile(filename: string, dir: string, stopDir?: string): string | null {
+  const path = findUp(filename, dir, stopDir);
   if (!path) return null;
   try {
-    const v = parse(readFileSync(path, "utf8"));
-    if (v && isSemver(v)) return stripV(v);
-  } catch {}
-  return null;
+    return readDeclaredVersion(path, readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
-export function readVersionFromPackageJson(projectRoot: string): string | null {
-  return readVersionFile("package.json", projectRoot, content => JSON.parse(content).version);
+export function readVersionFromPackageJson(projectRoot: string, stopDir?: string): string | null {
+  return readVersionFile("package.json", projectRoot, stopDir);
 }
 
 function pyprojectGet(content: string, key: string): string | undefined {
@@ -96,14 +96,28 @@ function pyprojectGet(content: string, key: string): string | undefined {
   return undefined;
 }
 
-export function readVersionFromPyprojectToml(projectRoot: string): string | null {
-  return readVersionFile("pyproject.toml", projectRoot, content => pyprojectGet(content, "version"));
+export function readVersionFromPyprojectToml(projectRoot: string, stopDir?: string): string | null {
+  return readVersionFile("pyproject.toml", projectRoot, stopDir);
+}
+
+// The version a manifest declares about itself, from content already in hand.
+export function readDeclaredVersion(file: string, data: string): string | null {
+  const fileName = basename(file);
+  try {
+    const version = fileName === "package.json" ? JSON.parse(data).version :
+      fileName === "pyproject.toml" ? pyprojectGet(data, "version") :
+        undefined;
+    // JSON.parse yields `any`, and the semver regex would coerce e.g. ["1.2.3"]
+    return typeof version === "string" && isSemver(version) ? stripV(version) : null;
+  } catch {
+    return null;
+  }
 }
 
 type BaseVersion = {baseVersion: string, baseSource: string, describeTag: string};
 
-export async function resolveBaseVersion(base: string | undefined, gitless: boolean, projectRoot: string): Promise<BaseVersion> {
-  if (base) {
+export async function resolveBaseVersion(base: string | undefined, gitless: boolean, projectRoot: string, stopDir?: string): Promise<BaseVersion> {
+  if (base !== undefined) {
     if (!isSemver(base)) throw new Error(`Invalid base version: ${base}`);
     return {baseVersion: stripV(base), baseSource: "--base", describeTag: ""};
   }
@@ -120,10 +134,10 @@ export async function resolveBaseVersion(base: string | undefined, gitless: bool
     if (tag) return {baseVersion: stripV(tag), baseSource: "git tag list", describeTag};
   }
 
-  const pkgVer = readVersionFromPackageJson(projectRoot);
+  const pkgVer = readVersionFromPackageJson(projectRoot, stopDir);
   if (pkgVer) return {baseVersion: pkgVer, baseSource: "package.json", describeTag};
 
-  const pyVer = readVersionFromPyprojectToml(projectRoot);
+  const pyVer = readVersionFromPyprojectToml(projectRoot, stopDir);
   if (pyVer) return {baseVersion: pyVer, baseSource: "pyproject.toml", describeTag};
 
   if (!gitless) return {baseVersion: "0.0.0", baseSource: "default", describeTag};

--- a/index.test.ts
+++ b/index.test.ts
@@ -244,6 +244,55 @@ version = "3.0.0"
   expect(await readFile(join(tmpDir, "testfile.txt"), "utf8")).toEqual("version 3.1.0");
 }));
 
+test("version files above the repo root are not used", () => withTmpDir(async (tmpDir) => {
+  const repoDir = join(tmpDir, "repo");
+  await mkdir(repoDir, {recursive: true});
+  await writeFile(join(tmpDir, "package.json"), JSON.stringify({name: "outer", version: "42.0.0"}));
+  await writeFile(join(repoDir, "testfile.txt"), "version 0.0.0");
+  await initGitRepo(repoDir);
+
+  const {stderr} = await exec("node", [distPath, "-D", "-V", "patch", "testfile.txt"], {cwd: repoDir});
+
+  expect(stderr).toContain("base version 0.0.0 from default");
+  expect(stderr).not.toContain("42.0.0");
+}));
+
+test("version file at the repo root is still found from a subdirectory", () => withTmpDir(async (tmpDir) => {
+  const subDir = join(tmpDir, "sub");
+  await mkdir(subDir, {recursive: true});
+  await writeFile(join(tmpDir, "package.json"), JSON.stringify({name: "test-pkg", version: "5.0.0"}));
+  await initGitRepo(tmpDir);
+
+  const {stderr} = await exec("node", [distPath, "-D", "-V", "patch"], {cwd: subDir});
+
+  expect(stderr).toContain("base version 5.0.0 from package.json");
+}));
+
+test("warns only when a manifest disagrees with a detected base version", () => withTmpDir(async (tmpDir) => {
+  await writeFile(join(tmpDir, "package.json"), JSON.stringify({name: "test-pkg", version: "9.9.9"}));
+  const {env} = await setupReleaseRepo(tmpDir); // tags 1.0.0
+  const opts = {cwd: tmpDir, env: {...process.env, ...env}};
+
+  expect((await exec("node", [distPath, "-D", "patch", "package.json"], opts)).stderr)
+    .toContain("warning: package.json declares 9.9.9 but the base version is 1.0.0");
+  // an explicit base is the user overriding detection, so a stale manifest says nothing
+  expect((await exec("node", [distPath, "-D", "--base=7.0.0", "patch", "package.json"], opts)).stderr).not.toContain("warning:");
+
+  await writeFile(join(tmpDir, "package.json"), JSON.stringify({name: "test-pkg", version: "1.0.0"}));
+  expect((await exec("node", [distPath, "-D", "patch", "package.json"], opts)).stderr).not.toContain("warning:");
+}));
+
+test("empty --base is rejected rather than ignored", () => withTmpDir(async (tmpDir) => {
+  let output;
+  try {
+    await exec("node", [distPath, "--gitless", "--base=", "patch", "package.json"], {cwd: tmpDir});
+  } catch (err) {
+    output = (err as SubprocessError).output;
+  }
+
+  expect(output).toContain("Invalid base version");
+}));
+
 test("prerelease from stable version", () => withTmpDir(async (tmpDir) => {
   await writeFile(join(tmpDir, "package.json"), JSON.stringify({name: "test-pkg", version: "1.0.0"}, null, 2));
   await writeFile(join(tmpDir, "testfile.txt"), "version 1.0.0");

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import {
-  findUp, resolveBaseVersion, incrementSemver, replaceTokens, getFileChanges,
+  findUp, resolveBaseVersion, incrementSemver, replaceTokens, getFileChanges, readDeclaredVersion,
   readChangelogEntry, updateChangelogHeadingDate, removeIgnoredFiles, joinStrings,
   write, writeResult, getRepoInfo, getForgeTokens, forgeName, probeRemote,
   pingForge, createForgeRelease, type RepoInfo,
@@ -110,7 +110,9 @@ async function main(): Promise<void> {
 
   const pwd = cwd();
   const gitDir = findUp(".git", pwd);
-  const projectRoot = gitDir ? dirname(gitDir) : pwd;
+  // bound version-file lookup at the repo root so a stray parent manifest can't set the base
+  const repoRoot = gitDir ? dirname(gitDir) : undefined;
+  const projectRoot = repoRoot ?? pwd;
   const pushRemote = typeof args.remote === "string" ? args.remote : "origin";
 
   // dedupe after normalizing, so `foo` and `./foo` collapse to one entry
@@ -126,6 +128,7 @@ async function main(): Promise<void> {
     typeof args.base === "string" ? args.base : undefined,
     Boolean(args.gitless),
     projectRoot,
+    repoRoot,
   );
   const pushBranchP: Promise<string> = willPush ? (async () => {
     if (typeof args.branch === "string") return args.branch;
@@ -189,7 +192,7 @@ async function main(): Promise<void> {
   })();
 
   const changelogInfo = (() => {
-    const path = findUp("CHANGELOG.md", projectRoot);
+    const path = findUp("CHANGELOG.md", projectRoot, repoRoot);
     if (!path) return null;
     let original: string;
     try {
@@ -225,6 +228,20 @@ async function main(): Promise<void> {
     remoteStateP, repoInfoP, tokensP, identityOkP, pingResultP, mergeBaseOkP,
   ]);
 
+  // A manifest that disagrees with a detected base means the base is likely wrong. The file check
+  // below cannot see it: manifest rewrites set the new version outright rather than replacing the
+  // base string, so they always produce a diff.
+  const warnings: string[] = [];
+  if (baseSource !== "--base") { // an explicit base overrides detection on purpose
+    for (const f of fileChanges) {
+      const declared = readDeclaredVersion(f.path, f.oldData);
+      // only a warning, a deliberately out-of-sync manifest is a legitimate setup
+      if (declared && declared !== baseVersion) {
+        warnings.push(`${f.path} declares ${declared} but the base version is ${baseVersion} (from ${baseSource})`);
+      }
+    }
+  }
+
   const errors: string[] = [];
 
   // If files were specified (and not -a), at least one must produce a diff — otherwise
@@ -258,6 +275,8 @@ async function main(): Promise<void> {
       errors.push(`--release: forge unreachable or token rejected: ${pingResult}`);
     }
   }
+
+  for (const warning of warnings) console.error(`warning: ${warning}`);
 
   if (errors.length > 0) {
     for (const e of errors) console.error(`error: ${e}`);


### PR DESCRIPTION
1. The upward search for `package.json`/`pyproject.toml` walked past the git root, so a parent directory's manifest could supply the base version. `CHANGELOG.md` had the same reach and was *written* to. Both are now bounded at the repo root, and stay unbounded outside a repo.
1. The "would not change any of the specified files" check never fires for manifests — `package.json`, `package-lock.json`, `pyproject.toml` and `uv.lock` all set the new version outright rather than replacing the base string, so they always produce a diff. Now warns when a manifest's declared version disagrees with a detected base, suppressed under an explicit `--base`.
1. `--base=` was silently ignored rather than rejected.

`readVersionFile` now delegates to the new `readDeclaredVersion` instead of taking a `parse` callback, which drops the duplicated manifest dispatch and semver guard.